### PR TITLE
use localStorage instead of sessionStorage to allow new tabs

### DIFF
--- a/src/api/baseApi.ts
+++ b/src/api/baseApi.ts
@@ -59,7 +59,7 @@ class BaseApi {
 
     requestInterceptor(req: InternalAxiosRequestConfig<any>): InternalAxiosRequestConfig<any> {
         let tokenToSendToFhirServer = 'jwt';
-        const identityProvider = sessionStorage.getItem('identityProvider');
+        const identityProvider = localStorage.getItem('identityProvider');
         if (identityProvider) {
             const authInfo = new AuthUrlProvider().getAuthInfo(identityProvider);
             tokenToSendToFhirServer = authInfo.tokenToSendToFhirServer || tokenToSendToFhirServer;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -30,6 +30,7 @@ const Header = () => {
                 // Clear local storage and user details
                 removeLocalData('jwt');
                 localStorage.removeItem('id_token');
+                localStorage.removeItem('identityProvider');
 
                 // Clear user context
                 if (setUserDetails) {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -21,7 +21,7 @@ const Header = () => {
 
     const handleLogout = async () => {
         try {
-            const identityProvider = sessionStorage.getItem('identityProvider');
+            const identityProvider = localStorage.getItem('identityProvider');
             if (identityProvider) {
                 const authService: IAuthService = AuthServiceFactory.getAuthService();
                 // Construct full logout URL

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -19,7 +19,7 @@ const Auth = () => {
             return;
         }
 
-        const identityProvider = sessionStorage.getItem('identityProvider');
+        const identityProvider = localStorage.getItem('identityProvider');
         if (!identityProvider) {
             console.error('No identity provider found in session storage');
             return;
@@ -43,7 +43,7 @@ const Auth = () => {
 
         setIsProcessing(true);
 
-        const identityProvider = sessionStorage.getItem('identityProvider');
+        const identityProvider = localStorage.getItem('identityProvider');
         if (!identityProvider) {
             console.error('No identity provider found in session storage');
             setIsProcessing(false);

--- a/src/pages/IdentityProviderSelection.tsx
+++ b/src/pages/IdentityProviderSelection.tsx
@@ -14,7 +14,7 @@ const IdentityProviderSelection = () => {
     console.log('Referring URL:', referringUrl);
 
     const handleProviderSelection = (provider: string) => {
-        sessionStorage.setItem('identityProvider', provider);
+        localStorage.setItem('identityProvider', provider);
         navigate('/authcallback', { state: { resourceUrl: referringUrl } });
     };
 

--- a/src/pages/IndexPage.tsx
+++ b/src/pages/IndexPage.tsx
@@ -176,7 +176,7 @@ const IndexPage = ({ search }: { search?: boolean }) => {
             try {
                 setLoading(true);
                 if (fhirUrl) {
-                    const identityProvider = sessionStorage.getItem('identityProvider');
+                    const identityProvider = localStorage.getItem('identityProvider');
                     if (!identityProvider) {
                         // noinspection ExceptionCaughtLocallyJS
                         throw new Error('Identity provider is not set');
@@ -233,7 +233,7 @@ const IndexPage = ({ search }: { search?: boolean }) => {
      * @param {SearchFormQuery} searchFormQuery
      */
     const handleSearch = (searchFormQuery: any) => {
-        const identityProvider = sessionStorage.getItem('identityProvider');
+        const identityProvider = localStorage.getItem('identityProvider');
         if (!identityProvider) {
             throw new Error('Identity provider is not set');
         }

--- a/src/services/AuthServiceFactory.ts
+++ b/src/services/AuthServiceFactory.ts
@@ -4,7 +4,7 @@ import { IAuthService } from './IAuthService';
 
 class AuthServiceFactory {
     static getAuthService(): IAuthService {
-        const identityProvider = sessionStorage.getItem('identityProvider');
+        const identityProvider = localStorage.getItem('identityProvider');
 
         if (!identityProvider) {
             throw new Error('No identity provider found in session storage');

--- a/src/utils/jwtParser.ts
+++ b/src/utils/jwtParser.ts
@@ -4,7 +4,7 @@ import { TUserDetails } from '../types/baseTypes';
 import AuthUrlProvider from './authUrlProvider';
 
 export const jwtParser = (): TUserDetails | null => {
-    const identityProvider = sessionStorage.getItem('identityProvider');
+    const identityProvider = localStorage.getItem('identityProvider');
     if (!identityProvider) {
         return null; // no identity provider has been chosen by the user yet
     }


### PR DESCRIPTION
This PR switches from using sessionStorage to localStorage for the identityProvider key, enabling authentication state to persist across browser tabs.

Replaced all sessionStorage.getItem/setItem calls for identityProvider with localStorage.
Updated storage usage in utilities, services, pages, components, and API interceptors.