### PR TITLE
show error in auth page

### DIFF
--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -39,7 +39,7 @@ const Auth = () => {
             window.location.href = redirect_to_login_url;
         } catch (error1) {
             console.error('Redirect to login failed', error1);
-            setError(`'Failed to redirect to login: ${redirect_to_login_url}: ${error1}}`);
+            setError(`Failed to redirect to login: ${redirect_to_login_url}: ${error1}`);
             setIsProcessing(false);
         }
     };

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -22,8 +22,8 @@ const Auth = () => {
 
         const identityProvider = localStorage.getItem('identityProvider');
         if (!identityProvider) {
-            console.error('No identity provider found in session storage');
-            setError('No identity provider found in session storage');
+            console.error('No identity provider found in local storage');
+            setError('No identity provider found in local storage');
             return;
         }
 
@@ -53,8 +53,8 @@ const Auth = () => {
 
         const identityProvider = localStorage.getItem('identityProvider');
         if (!identityProvider) {
-            console.error('No identity provider found in session storage');
-            setError('No identity provider found in session storage');
+            console.error('No identity provider found in local storage');
+            setError('No identity provider found in local storage');
             setIsProcessing(false);
             return;
         }

--- a/src/services/AuthServiceFactory.ts
+++ b/src/services/AuthServiceFactory.ts
@@ -7,7 +7,7 @@ class AuthServiceFactory {
         const identityProvider = localStorage.getItem('identityProvider');
 
         if (!identityProvider) {
-            throw new Error('No identity provider found in session storage');
+            throw new Error('No identity provider found in local storage');
         }
 
         switch (identityProvider.toLowerCase()) {


### PR DESCRIPTION
This PR updates the authentication page to display error messages to the user when authentication or token fetching fails.

Introduced an error state variable with useState to store error messages.
Updated redirection and token fetching error handling to set user-friendly error messages.